### PR TITLE
Added a license file using the BSD-3-Clause (new) license template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2007-2020, Atif Aziz, Joseph Albahari
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Hello Atif 

First, thank you for creating this useful library and choosing an open-source license for it. 

I am very strict when it comes to project licenses and this is usually the first thing I check before adopting an open-source library or component in my own work. I am using this particular library for quite some time and I am familiar with its license terms, but I've had bad luck locating its source-code repository for quite some time, until today (😊 ). 

Currently, the project's license terms are available in the [COPYING.txt](https://github.com/atifaziz/LINQBridge/blob/master/COPYING.txt) file, which is not automatically recognized by GitHub as the BSD-3-Clause license (I believe this is the right license this project is released under). The purpose of this commit is to make it more obvious for developers, who browse the repository, to identify the license -- its name should now appear on the right pane in the repository page and will link to the BSD-3-Clause license text. I achieved this using the BSD-3-Clause (new) license template form that is provided by GitHub, and changed copyright date to 2007-2020 (I was asked in the license template form and assumed the project is still active so the end-date should be 2020).

I'm hoping my cosmetic contribution is all fine with you.